### PR TITLE
add region support for boto3 s3 

### DIFF
--- a/awsbill2graphite.py
+++ b/awsbill2graphite.py
@@ -474,11 +474,13 @@ if __name__ == "__main__":
     logging.getLogger('boto').setLevel(logging.CRITICAL)
     logging.getLogger('boto3').setLevel(logging.CRITICAL)
     logging.getLogger('botocore').setLevel(logging.CRITICAL)
-    if os.getenv("REGION_NAME"):
+    if os.getenv("REGION_NAME") != '':
         region_name = os.getenv("REGION_NAME")
+    else: 
+        region_name = 'us-west-1'
     try:
         tempdir = tempfile.mkdtemp(".awsbill")
-        csv_file = open_csv(tempdir, region_name='us-west-1')
+        csv_file = open_csv(tempdir, region_name)
         output_file = open_output()
         generate_metrics(csv_file, output_file)
         logging.info("Removing temp directory '{0}'".format(tempdir))


### PR DESCRIPTION
if you have an s3 bucket in frankfurt this script will fail with the following:

ClientError: An error occurred (InvalidRequest) when calling the ListObjects operation: The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256.

This is due to Frankfurt having newer authorisation mechanisms in place.

Boto3 knows how to handle this when told the correct region.
